### PR TITLE
Only search valid cookbook directories

### DIFF
--- a/rules.rb
+++ b/rules.rb
@@ -30,7 +30,8 @@ end
 rule 'CINK002', 'Prefer single-quoted strings' do
   tags %w{style strings}
   cookbook do |path|
-    recipes = Dir["#{path}/**/*.rb"]
+    recipes  = Dir["#{path}/{#{standard_cookbook_subdirs.join(',')}}/**/*.rb"]
+    recipes += Dir["#{path}/*.rb"]
     recipes.collect do |recipe|
       lines = File.readlines(recipe)
 
@@ -52,7 +53,8 @@ end
 rule 'CINK003', 'Don\'t hardcode apache user or group' do
   tags %w{bug}
   cookbook do |path|
-    recipes = Dir["#{path}/**/*.rb"]
+    recipes  = Dir["#{path}/{#{standard_cookbook_subdirs.join(',')}}/**/*.rb"]
+    recipes += Dir["#{path}/*.rb"]
     recipes.collect do |recipe|
       lines = File.readlines(recipe)
 


### PR DESCRIPTION
This helps with test/spec directories.

It's not the most elegant solution, but I found that using this `Rakefile`:

``` ruby
require 'foodcritic'
task default: [:foodcritic]
FoodCritic::Rake::LintTask.new do |t|
  t.options = {
    include_rules: ['test/foodcritic'],
    exclude_paths: ['test', 'spec', 'features']
  }
end
```

these custom rules aren't enforcing the `exclude_paths` setting. However, I couldn't find a way to access these paths in the custom rule, so I decided to use the provided `standard_cookbook_subdirs` method.

Ideally, this would also be fixed on Foodcritic's side, passing along the excluded paths.
