### PR TITLE
Update rules.rb

### DIFF
--- a/rules.rb
+++ b/rules.rb
@@ -40,6 +40,7 @@ rule 'CINK002', 'Prefer single-quoted strings' do
         if line.match('"(.*)"') &&
           !line.match('\A\s*#') &&
           !line.match('\'(.*)"(.*)"(.*)\'') &&
+          !line.match('\`(.*)"(.*)"(.*)\`') &&
           !line.match('"(.*)(#{.+}|\'|\\\a|\\\b|\\\r|\\\n|\\\s|\\\t)(.*)"')
           {
             :filename => recipe,


### PR DESCRIPTION
I think we want to add another line for things we choose not to match on, so that we don't get hits on situations like the last line here:

```
bash 'add bin' do
  code <<-EOD
    found=`grep -c "PATH.*~/bin" /home/user/.bash_profile`
```
