### PR TITLE
modified rule a bit so it doesn't pull us up when we are escaping double quote

### DIFF
--- a/rules.rb
+++ b/rules.rb
@@ -38,6 +38,7 @@ rule 'CINK002', 'Prefer single-quoted strings' do
       lines.collect.with_index do |line, index|
         # Don't flag if there is a #{} or ' in the line
         if line.match('"(.*)"') &&
+          !line.match('\\"') &&
           !line.match('\A\s*#') &&
           !line.match('\'(.*)"(.*)"(.*)\'') &&
           !line.match('\`(.*)"(.*)"(.*)\`') &&


### PR DESCRIPTION
So this is to cover cases like this, where we need to use double quotes but they don't have two single quotes around them

```
command <<-EOF
    echo 'ins opt after /files/etc/fstab/*[file=\"/\"]/opt[last()]
    set /files/etc/fstab/*[file=\"/\"]/opt[last()] acl
    save' | augtool
    mount -o remount /
  EOF
```
